### PR TITLE
Add a class to the style element when dark contrast is enabled

### DIFF
--- a/src/palette.js
+++ b/src/palette.js
@@ -1101,7 +1101,14 @@ var pjs = {
 				if (this.styleElement) {
 					this.styleElement.style.backgroundImage = 'none';
 					this.styleElement.style.backgroundColor = '#' + this.toString();
-					this.styleElement.style.color = this.isLight() ? '#000' : '#FFF';
+
+					if (this.isLight()) {
+						this.styleElement.style.color = '#000';
+						jsc.unsetClass(this.styleElement, 'dark');
+					} else {
+						this.styleElement.style.color = '#FFF';
+						jsc.setClass(this.styleElement, 'dark');
+					}
 				}
 			}
 			if (!(flags & pjs.leavePad) && isPickerOwner()) {


### PR DESCRIPTION
This allows us to further style descendants of this element taking into
account the reversed contrast.

Closes: https://github.com/EastDesire/jscolor/pull/12